### PR TITLE
Update upload-pages-artifact & deploy-pages action versions

### DIFF
--- a/gh-pages/action.yml
+++ b/gh-pages/action.yml
@@ -60,7 +60,7 @@ runs:
       uses: actions/configure-pages@v3
     
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: '_site'
 

--- a/gh-pages/action.yml
+++ b/gh-pages/action.yml
@@ -66,4 +66,4 @@ runs:
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
The old `upload-pages-artifact` action was producing a deprecation warning:

<img width="991" alt="image" src="https://github.com/user-attachments/assets/2dc51d1e-f0cb-47ca-8167-a1e1bf2d504d" />

Example: https://github.com/Garciat/webgpu-playground/actions/runs/12507622275